### PR TITLE
Update examples to use app.run instead of app.run_server

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,4 +21,4 @@ app.layout = create_app_shell(page_registry.values(), fix_page_load_anchor_issue
 server = app.server
 
 if __name__ == '__main__':
-    app.run_server(port=7879)
+    app.run(port=7879)

--- a/components/attribution_control.py
+++ b/components/attribution_control.py
@@ -7,4 +7,4 @@ app.layout = dl.Map([
 ], attributionControl=False, center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/circle.py
+++ b/components/circle.py
@@ -10,4 +10,4 @@ app.layout = dl.Map([
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/circle_marker.py
+++ b/components/circle_marker.py
@@ -10,4 +10,4 @@ app.layout = dl.Map([
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/colorbar.py
+++ b/components/colorbar.py
@@ -9,4 +9,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6,  style={'height': '50vh'})
 
 if __name__ == "__main__":
-    app.run_server()
+    app.run()

--- a/components/div_marker.py
+++ b/components/div_marker.py
@@ -16,4 +16,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == "__main__":
-    app.run_server()
+    app.run()

--- a/components/easy_button.py
+++ b/components/easy_button.py
@@ -20,4 +20,4 @@ def log(n_clicks):
 
 
 if __name__ == "__main__":
-    app.run_server()
+    app.run()

--- a/components/edit_control.py
+++ b/components/edit_control.py
@@ -47,4 +47,4 @@ def trigger_action(n_clicks):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/feature_group.py
+++ b/components/feature_group.py
@@ -14,4 +14,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/full_screen_control.py
+++ b/components/full_screen_control.py
@@ -9,4 +9,4 @@ app.layout = dl.Map([
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/geojson.py
+++ b/components/geojson.py
@@ -26,4 +26,4 @@ def capital_click(feature):
         return f"You clicked {feature['properties']['name']}"
 
 if __name__ == '__main__':
-    app.run_server(port=7777)
+    app.run(port=7777)

--- a/components/gesture_handling.py
+++ b/components/gesture_handling.py
@@ -8,4 +8,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/image_overlay.py
+++ b/components/image_overlay.py
@@ -8,4 +8,4 @@ app.layout = dl.Map([
 ], bounds=image_bounds, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/layer_group.py
+++ b/components/layer_group.py
@@ -18,4 +18,4 @@ def generate_markers(_):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/layers_control.py
+++ b/components/layers_control.py
@@ -34,4 +34,4 @@ def log(base_layer, overlays):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/locate_control.py
+++ b/components/locate_control.py
@@ -7,4 +7,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/map_container.py
+++ b/components/map_container.py
@@ -7,4 +7,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/map_container_fly_to.py
+++ b/components/map_container_fly_to.py
@@ -16,4 +16,4 @@ def fly_to_paris(_):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/marker.py
+++ b/components/marker.py
@@ -20,4 +20,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/measure_control.py
+++ b/components/measure_control.py
@@ -9,4 +9,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/pane.py
+++ b/components/pane.py
@@ -10,4 +10,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/polygon.py
+++ b/components/polygon.py
@@ -8,4 +8,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/polyline.py
+++ b/components/polyline.py
@@ -8,4 +8,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/polyline_decorator.py
+++ b/components/polyline_decorator.py
@@ -35,4 +35,4 @@ app.layout = dl.Map([
 ], zoom=4, center=(52.0, -11.0), style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/popup.py
+++ b/components/popup.py
@@ -11,4 +11,4 @@ app.layout = dl.Map([
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/rectangle.py
+++ b/components/rectangle.py
@@ -8,4 +8,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/scale_control.py
+++ b/components/scale_control.py
@@ -7,4 +7,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/svg_overlay.py
+++ b/components/svg_overlay.py
@@ -19,4 +19,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=8, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run(debug=True)

--- a/components/tile_layer.py
+++ b/components/tile_layer.py
@@ -11,4 +11,4 @@ app.layout = dl.Map([
 ], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/tooltip.py
+++ b/components/tooltip.py
@@ -11,4 +11,4 @@ app.layout = dl.Map([
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/video_overlay.py
+++ b/components/video_overlay.py
@@ -21,4 +21,4 @@ def play_pause(n):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/components/wms_tile_layer.py
+++ b/components/wms_tile_layer.py
@@ -9,4 +9,4 @@ app.layout = dl.Map([
 ], center=[40, -100], zoom=4, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/choropleth_us.py
+++ b/docs/choropleth_us.py
@@ -53,4 +53,4 @@ def info_hover(feature):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/events_e.py
+++ b/docs/events_e.py
@@ -10,4 +10,4 @@ app.layout = Map(children=[TileLayer()], eventHandlers=eventHandlers,
                  style={'height': '50vh'}, center=[56, 10], zoom=6)
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/events_map.py
+++ b/docs/events_map.py
@@ -10,4 +10,4 @@ app.layout = Map(children=[TileLayer()], eventHandlers=eventHandlers,
                  style={'height': '50vh'}, center=[56, 10], zoom=6)
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/events_set_props.py
+++ b/docs/events_set_props.py
@@ -19,4 +19,4 @@ def log(message):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/func_props_arrow.py
+++ b/docs/func_props_arrow.py
@@ -10,4 +10,4 @@ app = DashProxy()
 app.layout = dl.Map(children=[dl.TileLayer(), geojson], style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/func_props_inline.py
+++ b/docs/func_props_inline.py
@@ -4,15 +4,15 @@ import dash_leaflet.express as dlx
 from dash_extensions.enrich import DashProxy
 from dash_extensions.javascript import assign
 
-# Create some markers.  
+# Create some markers.
 points = [dict(lat=55.5 + random.random(), lon=9.5 + random.random(), value=random.random()) for i in range(100)]
 data = dlx.dicts_to_geojson(points)
-# Create geojson.  
+# Create geojson.
 point_to_layer = assign("function(feature, latlng, context) {return L.circleMarker(latlng);}")
 geojson = dl.GeoJSON(data=data, pointToLayer=point_to_layer)
-# Create the app.  
+# Create the app.
 app = DashProxy()
 app.layout = dl.Map([dl.TileLayer(), geojson], center=(56, 10), zoom=8, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/func_props_js.py
+++ b/docs/func_props_js.py
@@ -15,4 +15,4 @@ app = DashProxy()
 app.layout = dl.Map([dl.TileLayer(), geojson], center=(56, 10), zoom=8, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/geojson_filter.py
+++ b/docs/geojson_filter.py
@@ -21,4 +21,4 @@ app.layout = html.Div([
 ])
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/geojson_flatgeobuf.py
+++ b/docs/geojson_flatgeobuf.py
@@ -26,4 +26,4 @@ def load_counties(click_data):
 
 
 if __name__ == '__main__':
-    app.run_server(port=8889)  # , debug=True)
+    app.run(port=8889)  # , debug=True)

--- a/docs/geojson_hideout.py
+++ b/docs/geojson_hideout.py
@@ -27,4 +27,4 @@ app.layout = html.Div([
 app.clientside_callback("function(x){return x;}", Output("geojson", "hideout"), Input("dd", "value"))
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/geojson_icon.py
+++ b/docs/geojson_icon.py
@@ -23,4 +23,4 @@ app.layout = html.Div([
 ])
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/geojson_select.py
+++ b/docs/geojson_select.py
@@ -36,4 +36,4 @@ def toggle_select(_, feature, hideout):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/measure_control_event.py
+++ b/docs/measure_control_event.py
@@ -24,4 +24,4 @@ def log(data):
 
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/minimal.py
+++ b/docs/minimal.py
@@ -5,4 +5,4 @@ app = DashProxy()
 app.layout = dl.Map(dl.TileLayer(), center=[56,10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/scatter_cluster.py
+++ b/docs/scatter_cluster.py
@@ -64,4 +64,4 @@ app = DashProxy(external_scripts=[chroma], prevent_initial_callbacks=True)
 app.layout = dl.Map([dl.TileLayer(), geojson, colorbar], center=[56, 10], zoom=6, style={'height': '50vh'})
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/scatter_plot.py
+++ b/docs/scatter_plot.py
@@ -32,4 +32,4 @@ app.layout = dl.Map([
 ], style={'height': '50vh'}, center=[56, 10], zoom=6)
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()

--- a/docs/super_cluster.py
+++ b/docs/super_cluster.py
@@ -15,4 +15,4 @@ app.layout = html.Div([
 ])
 
 if __name__ == '__main__':
-    app.run_server()
+    app.run()


### PR DESCRIPTION
Update examples to use `app.run` instead of `app.run_server`, which is being removed in Dash 3. https://github.com/plotly/dash/releases/tag/v3.0.0rc1
